### PR TITLE
Various improvements

### DIFF
--- a/client.go
+++ b/client.go
@@ -1916,6 +1916,8 @@ func normaliseError(err error) error {
 			return os.ErrNotExist
 		case sshFxPermissionDenied:
 			return os.ErrPermission
+		case sshFxFileAlreadyExists:
+			return os.ErrExist
 		case sshFxOk:
 			return nil
 		default:

--- a/client.go
+++ b/client.go
@@ -248,7 +248,7 @@ func NewClientPipe(rd io.Reader, wr io.WriteCloser, opts ...ClientOption) (*Clie
 // read/write at the same time. For those services you will need to use
 // `client.OpenFile(os.O_WRONLY|os.O_CREATE|os.O_TRUNC)`.
 func (c *Client) Create(path string) (*File, error) {
-	return c.open(path, flags(os.O_RDWR|os.O_CREATE|os.O_TRUNC))
+	return c.open(path, flags(os.O_RDWR|os.O_CREATE|os.O_TRUNC), defaultFileMode)
 }
 
 const sftpProtocolVersion = 3 // http://tools.ietf.org/html/draft-ietf-secsh-filexfer-02
@@ -567,22 +567,24 @@ func (c *Client) Truncate(path string, size int64) error {
 // returned file can be used for reading; the associated file descriptor
 // has mode O_RDONLY.
 func (c *Client) Open(path string) (*File, error) {
-	return c.open(path, flags(os.O_RDONLY))
+	return c.open(path, flags(os.O_RDONLY), 0)
 }
 
 // OpenFile is the generalized open call; most users will use Open or
 // Create instead. It opens the named file with specified flag (O_RDONLY
 // etc.). If successful, methods on the returned File can be used for I/O.
-func (c *Client) OpenFile(path string, f int) (*File, error) {
-	return c.open(path, flags(f))
+func (c *Client) OpenFile(path string, f int, mode os.FileMode) (*File, error) {
+	return c.open(path, flags(f), mode)
 }
 
-func (c *Client) open(path string, pflags uint32) (*File, error) {
+func (c *Client) open(path string, pflags uint32, mode os.FileMode) (*File, error) {
 	id := c.nextID()
 	typ, data, err := c.sendPacket(nil, &sshFxpOpenPacket{
 		ID:     id,
 		Path:   path,
 		Pflags: pflags,
+		Flags:  sshFileXferAttrPermissions,
+		Attrs:  toChmodPerm(mode),
 	})
 	if err != nil {
 		return nil, err
@@ -845,11 +847,13 @@ func (c *Client) Getwd() (string, error) {
 // Mkdir creates the specified directory. An error will be returned if a file or
 // directory with the specified path already exists, or if the directory's
 // parent folder does not exist (the method cannot create complete paths).
-func (c *Client) Mkdir(path string) error {
+func (c *Client) Mkdir(path string, mode os.FileMode) error {
 	id := c.nextID()
 	typ, data, err := c.sendPacket(nil, &sshFxpMkdirPacket{
-		ID:   id,
-		Path: path,
+		ID:    id,
+		Path:  path,
+		Flags: sshFileXferAttrPermissions,
+		Attrs: toChmodPerm(mode),
 	})
 	if err != nil {
 		return err
@@ -866,7 +870,7 @@ func (c *Client) Mkdir(path string) error {
 // and returns nil, or else returns an error.
 // If path is already a directory, MkdirAll does nothing and returns nil.
 // If path contains a regular file, an error is returned
-func (c *Client) MkdirAll(path string) error {
+func (c *Client) MkdirAll(path string, mode os.FileMode) error {
 	// Most of this code mimics https://golang.org/src/os/path.go?s=514:561#L13
 	// Fast path: if we can tell whether path is a directory or file, stop with success or error.
 	dir, err := c.Stat(path)
@@ -890,14 +894,14 @@ func (c *Client) MkdirAll(path string) error {
 
 	if j > 1 {
 		// Create parent
-		err = c.MkdirAll(path[0 : j-1])
+		err = c.MkdirAll(path[0:j-1], mode)
 		if err != nil {
 			return err
 		}
 	}
 
 	// Parent now exists; invoke Mkdir and use its result.
-	err = c.Mkdir(path)
+	err = c.Mkdir(path, mode)
 	if err != nil {
 		// Handle arguments like "foo/." by
 		// double-checking that directory doesn't exist.

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -303,7 +303,7 @@ func TestClientMkdir(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	sub := path.Join(dir, "mkdir1")
-	if err := sftp.Mkdir(sub); err != nil {
+	if err := sftp.Mkdir(sub, defaultDirMode); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Lstat(sub); err != nil {
@@ -322,7 +322,7 @@ func TestClientMkdirAll(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	sub := path.Join(dir, "mkdir1", "mkdir2", "mkdir3")
-	if err := sftp.MkdirAll(sub); err != nil {
+	if err := sftp.MkdirAll(sub, defaultDirMode); err != nil {
 		t.Fatal(err)
 	}
 	info, err := os.Lstat(sub)
@@ -490,7 +490,7 @@ func TestClientAppend(t *testing.T) {
 	defer f.Close()
 	defer os.Remove(f.Name())
 
-	f2, err := sftp.OpenFile(f.Name(), os.O_RDWR|os.O_APPEND)
+	f2, err := sftp.OpenFile(f.Name(), os.O_RDWR|os.O_APPEND, defaultFileMode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2209,7 +2209,7 @@ func TestServerRoughDisconnect3(t *testing.T) {
 	defer cmd.Wait()
 	defer sftp.Close()
 
-	dest, err := sftp.OpenFile("/dev/null", os.O_RDWR)
+	dest, err := sftp.OpenFile("/dev/null", os.O_RDWR, defaultFileMode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2240,7 +2240,7 @@ func TestServerRoughDisconnect4(t *testing.T) {
 	defer cmd.Wait()
 	defer sftp.Close()
 
-	dest, err := sftp.OpenFile("/dev/null", os.O_RDWR)
+	dest, err := sftp.OpenFile("/dev/null", os.O_RDWR, defaultFileMode)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -124,7 +124,7 @@ func ExampleClient_Mkdir_parents() {
 				continue
 			}
 			parents = path.Join(parents, name)
-			err = client.Mkdir(parents)
+			err = client.Mkdir(parents, 0o750)
 			if status, ok := err.(*sftp.StatusError); ok {
 				if status.Code == sshFxFailure {
 					var fi os.FileInfo

--- a/packet.go
+++ b/packet.go
@@ -662,12 +662,13 @@ type sshFxpOpenPacket struct {
 	ID     uint32
 	Path   string
 	Pflags uint32
-	Flags  uint32 // ignored
+	Flags  uint32
+	Attrs  interface{}
 }
 
 func (p *sshFxpOpenPacket) id() uint32 { return p.ID }
 
-func (p *sshFxpOpenPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpOpenPacket) marshalPacket() ([]byte, []byte, error) {
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4 + len(p.Path) +
 		4 + 4
@@ -679,7 +680,14 @@ func (p *sshFxpOpenPacket) MarshalBinary() ([]byte, error) {
 	b = marshalUint32(b, p.Pflags)
 	b = marshalUint32(b, p.Flags)
 
-	return b, nil
+	payload := marshal(nil, p.Attrs)
+
+	return b, payload, nil
+}
+
+func (p *sshFxpOpenPacket) MarshalBinary() ([]byte, error) {
+	header, payload, err := p.marshalPacket()
+	return append(header, payload...), err
 }
 
 func (p *sshFxpOpenPacket) UnmarshalBinary(b []byte) error {
@@ -690,9 +698,10 @@ func (p *sshFxpOpenPacket) UnmarshalBinary(b []byte) error {
 		return err
 	} else if p.Pflags, b, err = unmarshalUint32Safe(b); err != nil {
 		return err
-	} else if p.Flags, _, err = unmarshalUint32Safe(b); err != nil {
+	} else if p.Flags, b, err = unmarshalUint32Safe(b); err != nil {
 		return err
 	}
+	p.Attrs = b
 	return nil
 }
 
@@ -864,13 +873,14 @@ func (p *sshFxpWritePacket) UnmarshalBinary(b []byte) error {
 
 type sshFxpMkdirPacket struct {
 	ID    uint32
-	Flags uint32 // ignored
 	Path  string
+	Flags uint32
+	Attrs interface{}
 }
 
 func (p *sshFxpMkdirPacket) id() uint32 { return p.ID }
 
-func (p *sshFxpMkdirPacket) MarshalBinary() ([]byte, error) {
+func (p *sshFxpMkdirPacket) marshalPacket() ([]byte, []byte, error) {
 	l := 4 + 1 + 4 + // uint32(length) + byte(type) + uint32(id)
 		4 + len(p.Path) +
 		4 // uint32
@@ -881,7 +891,14 @@ func (p *sshFxpMkdirPacket) MarshalBinary() ([]byte, error) {
 	b = marshalString(b, p.Path)
 	b = marshalUint32(b, p.Flags)
 
-	return b, nil
+	payload := marshal(nil, p.Attrs)
+
+	return b, payload, nil
+}
+
+func (p *sshFxpMkdirPacket) MarshalBinary() ([]byte, error) {
+	header, payload, err := p.marshalPacket()
+	return append(header, payload...), err
 }
 
 func (p *sshFxpMkdirPacket) UnmarshalBinary(b []byte) error {
@@ -890,9 +907,10 @@ func (p *sshFxpMkdirPacket) UnmarshalBinary(b []byte) error {
 		return err
 	} else if p.Path, b, err = unmarshalStringSafe(b); err != nil {
 		return err
-	} else if p.Flags, _, err = unmarshalUint32Safe(b); err != nil {
+	} else if p.Flags, b, err = unmarshalUint32Safe(b); err != nil {
 		return err
 	}
+	p.Attrs = b
 	return nil
 }
 

--- a/server.go
+++ b/server.go
@@ -816,8 +816,12 @@ func statusFromError(id uint32, err error) *sshFxpStatusPacket {
 	ret.StatusError.Code = sshFxFailure
 	ret.StatusError.msg = err.Error()
 
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		ret.StatusError.Code = sshFxNoSuchFile
+		return ret
+	}
+	if errors.Is(err, os.ErrExist) {
+		ret.StatusError.Code = sshFxFileAlreadyExists
 		return ret
 	}
 	if code, ok := translateSyscallError(err); ok {

--- a/stat_posix.go
+++ b/stat_posix.go
@@ -24,6 +24,8 @@ func translateErrno(errno syscall.Errno) uint32 {
 		return sshFxOk
 	case syscall.ENOENT:
 		return sshFxNoSuchFile
+	case syscall.EEXIST:
+		return sshFxFileAlreadyExists
 	case syscall.EACCES, syscall.EPERM:
 		return sshFxPermissionDenied
 	}


### PR DESCRIPTION
- Fix incorrect flags getting passed to request callback for `Open` client calls
- Send server-side `EEXIST` or `os.ErrNotExist` errors to client
- Allow clients to specify file permissions when creating files/directories
- Pass permissions to request callback for `Open` and `Mkdir` calls