### PR TITLE
Set correct permissions on MKDIR

### DIFF
--- a/server.go
+++ b/server.go
@@ -296,7 +296,7 @@ func handlePacket(s *Server, p orderedRequest) error {
 			Err:  err,
 		})
 	case *sshFxpMkdirPacket:
-		var mode os.FileMode = defaultFileMode
+		var mode os.FileMode = 0o755
 		var attributes *Attributes
 		if p.Attrs != nil {
 			attrs, _ := unmarshalFileStat(p.Flags, p.Attrs.([]byte))


### PR DESCRIPTION
Currently, our fork sets wrong permissions on created directories. Removed execute permission doesn't allow listing files after the directory is created. The upstream version uses https://github.com/pkg/sftp/blob/971c283182b6806d66643a197c7a7ff2605fdfdc/server.go#L222, which sounds like the correct default.

Related https://github.com/gravitational/teleport/issues/22263